### PR TITLE
Use reasonable modern target version and lighter code style

### DIFF
--- a/src/api/interchainaccounts.ts
+++ b/src/api/interchainaccounts.ts
@@ -1,4 +1,4 @@
-import { DirectSecp256k1HdWallet, Registry, GeneratedType } from "@cosmjs/proto-signing";
+import { DirectSecp256k1HdWallet, Registry } from "@cosmjs/proto-signing";
 import { createProtobufRpcClient, QueryClient } from "@cosmjs/stargate";
 import { toAccAddress } from "@cosmjs/stargate/build/queries/utils"
 import { defaultRegistryTypes, SigningStargateClient, coins } from "@cosmjs/stargate";
@@ -8,11 +8,10 @@ import { MsgRegisterAccount, MsgSend as InterTxMsgSend } from "../codec/intertx/
 import { QueryClientImpl } from "../codec/intertx/query";
 import { Tendermint34Client } from "@cosmjs/tendermint-rpc";
 
-const myTypes: ReadonlyArray<[string, GeneratedType]> = [["/intertx.MsgRegisterAccount", MsgRegisterAccount],["/intertx.MsgSend", InterTxMsgSend]]
-
 const myRegistry = new Registry([
   ...defaultRegistryTypes,
-  ...myTypes,
+  ["/intertx.MsgRegisterAccount", MsgRegisterAccount],
+  ["/intertx.MsgSend", InterTxMsgSend],
 ]);
 
 const MNEMONIC_1 = // Replace with your own mnemonic

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
As discussed in chat recently. The es5 target type triggers the use of some strange TypeScript types with yield results. Since CosmJS code is compiled for es2017, this app does not work on older clients anyways. This change makes your life easier.